### PR TITLE
optimize label bot

### DIFF
--- a/mxnet-bot/LabelBotAddLabels/LabelBot.py
+++ b/mxnet-bot/LabelBotAddLabels/LabelBot.py
@@ -42,7 +42,7 @@ class LabelBot:
                      auth = self.auth)
         res.raise_for_status()
         data = res.json()['rate']
-        logging.info("current API status: " + data)
+        logging.info("current API status: " + str(data))
 
     def get_secret(self):
         """
@@ -80,7 +80,7 @@ class LabelBot:
                                           'per_page': 100}, auth=self.auth)
         else:
             response = requests.get(url, auth=self.auth)
-        assert response.status_code == 200, response.status_code
+        response.raise_for_status()
         if "link" not in response.headers:
             return 1
         return int(self.clean_string(response.headers['link'], " ").split()[-3])
@@ -114,7 +114,7 @@ class LabelBot:
                         for comment in comments:
                             if "@mxnet-label-bot" in comment['body']:
                                 labels += self.tokenize(comment['body'])
-                                logging.info("issue: {}, comment: {}".format(str(item['number']),comment['body']))
+                                logging.debug("issue: {}, comment: {}".format(str(item['number']),comment['body']))
                         if labels != []:
                             issues.append({"issue": item['number'], "labels": labels})
         return issues
@@ -162,4 +162,3 @@ class LabelBot:
         self.find_all_labels()
         for issue in issues:
             self.add_github_labels(issue['issue'], issue['labels'])
-

--- a/mxnet-bot/LabelBotAddLabels/LabelBot.py
+++ b/mxnet-bot/LabelBotAddLabels/LabelBot.py
@@ -37,6 +37,13 @@ class LabelBot:
         self.auth = (self.github_user, self.github_oauth_token)
         self.all_labels = None
 
+    def get_rate_limit(self):
+        res = requests.get('https://api.github.com/{}'.format('rate_limit'),
+                     auth = self.auth)
+        res.raise_for_status()
+        data = res.json()['rate']
+        logging.info("current API status: " + data)
+
     def get_secret(self):
         """
         This method is to get secret value from Secrets Manager

--- a/mxnet-bot/LabelBotAddLabels/LabelBot.py
+++ b/mxnet-bot/LabelBotAddLabels/LabelBot.py
@@ -43,6 +43,7 @@ class LabelBot:
         res.raise_for_status()
         data = res.json()['rate']
         logging.info("current API status: " + str(data))
+        return data['remaining']
 
     def get_secret(self):
         """

--- a/mxnet-bot/LabelBotAddLabels/LabelBot.py
+++ b/mxnet-bot/LabelBotAddLabels/LabelBot.py
@@ -42,7 +42,6 @@ class LabelBot:
                      auth = self.auth)
         res.raise_for_status()
         data = res.json()['rate']
-        logging.info("current API status: " + str(data))
         return data['remaining']
 
     def get_secret(self):

--- a/mxnet-bot/LabelBotAddLabels/LabelBot.py
+++ b/mxnet-bot/LabelBotAddLabels/LabelBot.py
@@ -60,7 +60,7 @@ class LabelBot:
         cleans = re.sub("[^0-9a-zA-Z]", sub_string, raw_string)
         return cleans.lower()
 
-    def count_pages(self, obj, state='all'):
+    def count_pages(self, obj, state='open'):
         """
         This method is to count how many pages of issues/labels in total
         obj could be "issues"/"labels"
@@ -70,7 +70,7 @@ class LabelBot:
         url = 'https://api.github.com/repos/{}/{}'.format(self.repo, obj)
         if obj == 'issues':
             response = requests.get(url, {'state': state,
-                                          'q': 'no:label+is:open'}, auth=self.auth)
+                                          'per_page': 100}, auth=self.auth)
         else:
             response = requests.get(url, auth=self.auth)
         assert response.status_code == 200, response.status_code
@@ -92,9 +92,8 @@ class LabelBot:
                                      'base': 'master',
                                      'sort': 'created',
                                      'direction': 'desc',
-                                     'page': str(page),
-                                     'per_page': '30',
-                                     'q': 'no:label+is:open'},
+                                     'page': page,
+                                     'per_page': 100},
                                      auth=self.auth)
             for item in response.json():
                 # limit the amount of unlabeled issues per execution

--- a/mxnet-bot/LabelBotAddLabels/LabelBot.py
+++ b/mxnet-bot/LabelBotAddLabels/LabelBot.py
@@ -69,7 +69,8 @@ class LabelBot:
         assert obj in set(["issues", "labels"]), "Invalid Input!"
         url = 'https://api.github.com/repos/{}/{}'.format(self.repo, obj)
         if obj == 'issues':
-            response = requests.get(url, {'state': state}, auth=self.auth)    
+            response = requests.get(url, {'state': state,
+                                          'q': 'no:label+is:open'}, auth=self.auth)
         else:
             response = requests.get(url, auth=self.auth)
         assert response.status_code == 200, response.status_code
@@ -80,17 +81,20 @@ class LabelBot:
     def find_notifications(self):
         """
         This method is to find comments which @mxnet-label-bot
+        @:return [{"issue" : issue_id, "labels": []},...]
         """
         issues = []
         pages = self.count_pages("issues")
         for page in range(1, pages+1):
-            url = 'https://api.github.com/repos/' + self.repo + '/issues?page=' + str(page) \
-                + '&per_page=30'.format(repo=self.repo)
+            url = 'https://api.github.com/repos/{}/{}'.format(self.repo, 'issues')
             response = requests.get(url,
                                     {'state': 'open',
                                      'base': 'master',
                                      'sort': 'created',
-                                     'direction': 'desc'},
+                                     'direction': 'desc',
+                                     'page': str(page),
+                                     'per_page': '30',
+                                     'q': 'no:label+is:open'},
                                      auth=self.auth)
             for item in response.json():
                 # limit the amount of unlabeled issues per execution

--- a/mxnet-bot/LabelBotAddLabels/handler.py
+++ b/mxnet-bot/LabelBotAddLabels/handler.py
@@ -24,9 +24,12 @@ logging.getLogger('botocore').setLevel(logging.CRITICAL)
 
 def label_bot_lambda(event, context):
     lb = LabelBot(secret=True)
-    lb.get_rate_limit()
-    data = lb.find_notifications()
-    lb.label(data)
-    lb.get_rate_limit()
-    return "Lambda is triggered successfully!"
+    remaining = lb.get_rate_limit()
+    if remaining >= 4000:
+        data = lb.find_notifications()
+        lb.label(data)
+        lb.get_rate_limit()
+        return "Lambda is triggered successfully!"
+    else:
+        return "Lambda failed triggered (out of limits)"
 

--- a/mxnet-bot/LabelBotAddLabels/handler.py
+++ b/mxnet-bot/LabelBotAddLabels/handler.py
@@ -24,7 +24,9 @@ logging.getLogger('botocore').setLevel(logging.CRITICAL)
 
 def label_bot_lambda(event, context):
     lb = LabelBot(secret=True)
+    lb.get_rate_limit()
     data = lb.find_notifications()
     lb.label(data)
+    lb.get_rate_limit()
     return "Lambda is triggered successfully!"
 

--- a/mxnet-bot/LabelBotAddLabels/handler.py
+++ b/mxnet-bot/LabelBotAddLabels/handler.py
@@ -29,7 +29,7 @@ def label_bot_lambda(event, context):
         data = lb.find_notifications()
         lb.label(data)
         lb.get_rate_limit()
-        return "Lambda is triggered successfully!"
+        return "Lambda is triggered successfully! (remaining HTTP request: {}".format(remaining)
     else:
-        return "Lambda failed triggered (out of limits)"
+        return "Lambda failed triggered (out of limits: {})".format(remaining)
 

--- a/mxnet-bot/LabelBotAddLabels/handler.py
+++ b/mxnet-bot/LabelBotAddLabels/handler.py
@@ -28,8 +28,8 @@ def label_bot_lambda(event, context):
     if remaining >= 4000:
         data = lb.find_notifications()
         lb.label(data)
-        lb.get_rate_limit()
-        return "Lambda is triggered successfully! (remaining HTTP request: {}".format(remaining)
+        remaining = lb.get_rate_limit()
+        return "Lambda is triggered successfully! (remaining HTTP request: {})".format(remaining)
     else:
         return "Lambda failed triggered (out of limits: {})".format(remaining)
 


### PR DESCRIPTION
@marcoabreu @larroy these few lines will optimize the number of queries for the Label bot.

I add the filter on the issues to only track unlabelled open issues.

Previously: more than 200 HTTP requests for getting unlabelled issues
Now: 2, since there is only 44 there...

please set the update time to 5 min!