### PR TITLE
Add deployment configuration for label bot

### DIFF
--- a/mxnet-bot/LabelBotAddLabels/.gitignore
+++ b/mxnet-bot/LabelBotAddLabels/.gitignore
@@ -1,0 +1,1 @@
+.serverless

--- a/mxnet-bot/LabelBotAddLabels/deploy_bot.sh
+++ b/mxnet-bot/LabelBotAddLabels/deploy_bot.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Script to deploy the label bot to our dev account
+set -e
+
+export AWS_PROFILE=mxnet-ci-dev
+sls deploy

--- a/mxnet-bot/LabelBotAddLabels/serverless.yml
+++ b/mxnet-bot/LabelBotAddLabels/serverless.yml
@@ -37,7 +37,6 @@ provider:
        Action:
          - "secretsmanager:GetSecretValue"
          - "secretsmanager:DescribeSecret"
-       # replace resource with your secret's ARN
        Resource: "arn:aws:secretsmanager:us-west-2:139068448383:secret:GitHubLabelBotCredentials-7WcyTN"
     -  Effect: "Allow"
        Action:
@@ -51,9 +50,6 @@ functions:
     events:
       - schedule: rate(5 minutes)
     environment:
-    # replace region_name with your secret's region
       region_name : "us-west-2"
-    # replace secret_name with your secret's name
       secret_name : "GitHubLabelBotCredentials"
-    # replace REPO with "apache/incubator-mxnet"
       repo : "apache/incubator-mxnet"

--- a/mxnet-bot/LabelBotAddLabels/serverless.yml
+++ b/mxnet-bot/LabelBotAddLabels/serverless.yml
@@ -30,6 +30,7 @@ package:
 provider:
   name: aws
   runtime: python3.6
+  region: us-west-2
   timeout: 180
   iamRoleStatements:
     -  Effect: "Allow"
@@ -37,7 +38,7 @@ provider:
          - "secretsmanager:GetSecretValue"
          - "secretsmanager:DescribeSecret"
        # replace resource with your secret's ARN
-       Resource: "arn:aws:secretsmanager:{region_name}:{account_id}:secret:{secret_id}"
+       Resource: "arn:aws:secretsmanager:us-west-2:139068448383:secret:GitHubLabelBotCredentials-7WcyTN"
     -  Effect: "Allow"
        Action:
          - "secretsmanager:ListSecrets"
@@ -51,8 +52,8 @@ functions:
       - schedule: rate(5 minutes)
     environment:
     # replace region_name with your secret's region
-      region_name : "us-east-1"
+      region_name : "us-west-2"
     # replace secret_name with your secret's name
-      secret_name : "secret_name"
+      secret_name : "GitHubLabelBotCredentials"
     # replace REPO with "apache/incubator-mxnet"
-      repo : "repo_name"
+      repo : "apache/incubator-mxnet"


### PR DESCRIPTION
This PR adds the deployment configuration we use to deploy the label bot on the dev account.