### PR TITLE
Functionality to support custom domain name

### DIFF
--- a/mxnet-bot/LabelBotFullFunctionality/README.md
+++ b/mxnet-bot/LabelBotFullFunctionality/README.md
@@ -14,7 +14,11 @@ This bot serves to help non-committers add labels to GitHub issues.
 * Configure ***variables.tf***
     1. In variable "github_credentials", fill in github_user and github_oauth_token. If you don't want to fill in here, then you can leave them blank.
        After you set up a secret, you can go to [AWS Secrets Manager Console](https://console.aws.amazon.com/secretsmanager) console to manually fill in secret values.
-    2. In variable "secret_name", fill in the name of your secret. ie:"github/credentials"
+    2. In configuring a webhook for github, confirm that the content type you have set is of application/json and that the appropriate events that you would like to
+       trigger the webhook for are set. As an additional security measure,  under Content type configure a secret for your webhook. 
+       Be sure to include this secret as well in the variables.tf file (as a part of webhook_secret). Similarly, you can leave this blank and fill it in
+       later in the secrets manager console. 
+    3. In variable "secret_name", fill in the name of your secret. ie:"github/credentials"
 
 **Note:** Do *not*  commit credentials that you have assigned in variables.tf to the GitHub repo
 

--- a/mxnet-bot/LabelBotFullFunctionality/README.md
+++ b/mxnet-bot/LabelBotFullFunctionality/README.md
@@ -61,3 +61,13 @@ One thing to mention: this IAM role only has ***Read*** access to the secret cre
     <div align="center">
         <img src="https://s3-us-west-2.amazonaws.com/email-boy-images/Screen+Shot+2018-07-31+at+3.10.26+PM.png" width="600" height="150"><br>
     </div>
+
+#### 4. DNS Service
+* In serverless.yml within the customDomain section specify the domain name you would like to use.
+* Similarly, specify the basePath and the stage (this correlates to your API Gateway function) i.e. /dev and dev stage.
+* After this run serverless create-domain (process may take some time and is meant to only run once)
+* You will need to request a Certificate for your new domain, so under AWS Certificate Manager add your domain name and validate using DNS service.
+* Afterwards run serverless deploy -v
+* Specify this domain name (and the specific endpoint where your function points to in the API Gateway Console)
+
+***Note:*** Verify that ACM certificate is created in us-east-1 (for edge apis) and is present and matches the certificate in the certificate section of API Gateway (Custom Domain Names)

--- a/mxnet-bot/LabelBotFullFunctionality/README.md
+++ b/mxnet-bot/LabelBotFullFunctionality/README.md
@@ -71,3 +71,6 @@ One thing to mention: this IAM role only has ***Read*** access to the secret cre
 * Specify this domain name (and the specific endpoint where your function points to in the API Gateway Console)
 
 ***Note:*** Verify that ACM certificate is created in us-east-1 (for edge apis) and is present and matches the certificate in the certificate section of API Gateway (Custom Domain Names)
+
+When wanting to update the stack using serverless deploy after initial launch, comment out
+in serverless.yml file the section regarding customDomain and plugins.

--- a/mxnet-bot/LabelBotFullFunctionality/buildspec.yml
+++ b/mxnet-bot/LabelBotFullFunctionality/buildspec.yml
@@ -5,6 +5,9 @@ phases:
     commands:
       - echo In install phase...
       - npm install -g serverless
+      - npm init -y
+      - npm install serverless-domain-manager --save-dev
+
   build:
     commands:
       - echo In build phase...

--- a/mxnet-bot/LabelBotFullFunctionality/deploy_bot.sh
+++ b/mxnet-bot/LabelBotFullFunctionality/deploy_bot.sh
@@ -3,5 +3,4 @@
 set -e
 
 export AWS_PROFILE=mxnet-ci-dev
-sls create_domain
 sls deploy -v

--- a/mxnet-bot/LabelBotFullFunctionality/deploy_bot.sh
+++ b/mxnet-bot/LabelBotFullFunctionality/deploy_bot.sh
@@ -3,4 +3,5 @@
 set -e
 
 export AWS_PROFILE=mxnet-ci-dev
-sls deploy
+sls create_domain
+sls deploy -v

--- a/mxnet-bot/LabelBotFullFunctionality/serverless.yml
+++ b/mxnet-bot/LabelBotFullFunctionality/serverless.yml
@@ -25,9 +25,9 @@ plugins:
 custom:
   queueName: LabelSQS
   customDomain:
-    domainName:
-    basePath: ''
-    stage: $(self:provider.stage)
+    domainName: 'deploy.mxnet-label-bot.de'
+    basePath: '/dev'
+    stage: dev
     createRoute53Record: true
 
 package:

--- a/mxnet-bot/LabelBotFullFunctionality/serverless.yml
+++ b/mxnet-bot/LabelBotFullFunctionality/serverless.yml
@@ -19,8 +19,16 @@
 
 service: LabelBot
 
+plugins:
+  - serverless-domain-manager
+
 custom:
   queueName: LabelSQS
+  customDomain:
+    domainName:
+    basePath: ''
+    stage: $(self:provider.stage)
+    createRoute53Record: true
 
 package:
   exclude:

--- a/mxnet-bot/LabelBotFullFunctionality/variables.tf
+++ b/mxnet-bot/LabelBotFullFunctionality/variables.tf
@@ -2,6 +2,7 @@ variable "github_credentials" {
   default = {
     github_user = ""
     github_oauth_token  = ""
+    webhook_secret = ""
   }
   type = "map"
 }


### PR DESCRIPTION
- In redeploying of the service: a custom domain name can be added under (domainName). This allows for a fixed domain for the service to operate on
- Build scripts reflect this change so that when deployed with CodePipeline - we can build our label bot appropriately with the changes presented by a custom domain