### PR TITLE
Fix instructions and change production config

### DIFF
--- a/mxnet-bot/LabelBotFullFunctionality/.gitignore
+++ b/mxnet-bot/LabelBotFullFunctionality/.gitignore
@@ -3,3 +3,5 @@
 .terraform
 terraform.tfstate
 terraform.tfstate.backup
+node_modules
+package-lock.json

--- a/mxnet-bot/LabelBotFullFunctionality/README.md
+++ b/mxnet-bot/LabelBotFullFunctionality/README.md
@@ -65,8 +65,9 @@ One thing to mention: this IAM role only has ***Read*** access to the secret cre
 #### 4. DNS Service
 * In serverless.yml within the customDomain section specify the domain name you would like to use.
 * Similarly, specify the basePath and the stage (this correlates to your API Gateway function) i.e. /dev and dev stage.
-* After this run serverless create-domain (process may take some time and is meant to only run once)
 * You will need to request a Certificate for your new domain, so under AWS Certificate Manager add your domain name and validate using DNS service.
+* To install the plugin, run ``npm install serverless-domain-manager --save-dev``.
+* After this run ``serverless create_domain`` (process may take some time and is meant to only run once)
 * Afterwards run serverless deploy -v
 * Specify this domain name (and the specific endpoint where your function points to in the API Gateway Console)
 

--- a/mxnet-bot/LabelBotFullFunctionality/serverless.yml
+++ b/mxnet-bot/LabelBotFullFunctionality/serverless.yml
@@ -25,8 +25,8 @@ plugins:
 custom:
   queueName: LabelSQS
   customDomain:
-    domainName: 'deploy.mxnet-label-bot.de'
-    basePath: '/dev'
+    domainName: 'labelbot-webhook.mxnet-ci-dev.amazon-ml.com'
+    basePath: 'dev'
     stage: dev
     createRoute53Record: true
 

--- a/mxnet-bot/LabelBotFullFunctionality/serverless.yml
+++ b/mxnet-bot/LabelBotFullFunctionality/serverless.yml
@@ -17,7 +17,7 @@
 # under the License.
 # Configurations
 
-service: LabelBot
+service: LabelBotFull
 
 plugins:
   - serverless-domain-manager

--- a/mxnet-bot/LabelBotFullFunctionality/serverless.yml
+++ b/mxnet-bot/LabelBotFullFunctionality/serverless.yml
@@ -56,6 +56,9 @@ provider:
     -  Effect: "Allow"
        Action:
          - "sqs:SendMessage"
+         - "sqs:ReceiveMessage"
+         - "sqs:DeleteMessage"
+         - "sqs:GetQueueAttributes"
        Resource:
          Fn::GetAtt: [ SQSQueue, Arn ]
 


### PR DESCRIPTION
This PR updates the config of the full labelbot with the production config.

I have taken the following steps:

1. Enhanced the README.md to match the right order the steps have to be executed.
2. Created an SSL certificate at https://us-east-1.console.aws.amazon.com/acm/home?region=us-east-1#/?id=arn:aws:acm:us-east-1:139068448383:certificate%2F70190554-d7a2-45e8-b4b5-0859ea42af23:
![image](https://user-images.githubusercontent.com/18629099/48129404-aca9b480-e289-11e8-95ee-9c69889aca6e.png)
3. Changed the DNS entry to match the new domain
4. Ran ``serverless create_domain`` to create the Route53 entry - worked like a charm
5. Changed the basePath since it contained an illegal character and failed the deployment with the following message:
```
  Serverless Error ---------------------------------------

  An error occurred: pathmapping - A base path may contain only letters, numbers and one of $-_.+!*'(), (Service: AmazonApiGateway; Status Code: 400; Error Code: BadRequestException; Request ID: e6584ab6-e27f-11e8-ba9c-fd8ba79f49cf).

  Get Support --------------------------------------------
     Docs:          docs.serverless.com
     Bugs:          github.com/serverless/serverless/issues
     Forums:        forum.serverless.com
     Chat:          gitter.im/serverless/serverless

  Your Environment Information -----------------------------
     OS:                     darwin
     Node Version:           8.9.4
     Serverless Version:     1.26.1
```
6. Ran ``./deploy_bot.sh`` to deploy the bot. The output was as follows:
```
erverless: Stack update finished...
Service Information
service: LabelBot
stage: dev
.serverless
region: us-west-2
.serverless
stack: LabelBot-dev
api keys:
  None
endpoints:
  POST - https://htw1tprygi.execute-api.us-west-2.amazonaws.com/dev/send_to_sqs
functions:
  send: LabelBot-dev-send
  label: LabelBot-dev-label

Stack Outputs
LabelLambdaFunctionQualifiedArn: arn:aws:lambda:us-west-2:139068448383:function:LabelBot-dev-label:6
DomainName: dbhmi6qz7fovu.cloudfront.net
HostedZoneId: Z2FDTNDATAQYW2
SendLambdaFunctionQualifiedArn: arn:aws:lambda:us-west-2:139068448383:function:LabelBot-dev-send:3
ServiceEndpoint: https://htw1tprygi.execute-api.us-west-2.amazonaws.com/dev
ServerlessDeploymentBucketName: labelbot-dev-serverlessdeploymentbucket-1hp259hf80a7d

Serverless Domain Manager Summary
Domain Name
  labelbot-webhook.mxnet-ci-dev.amazon-ml.com
Distribution Domain Name
  dbhmi6qz7fovu.cloudfront.net
```
7. Since the design of the stack did not allow parallel deployment of the old and the new bot, I reverted that deployment and re-deployed the old bot to avoid any service disruption.

The next step is a ticket from Harsh to the dev-list to request an Apache-Infra ticket with the mentors. After that ticket has been created, I will follow up to create the webhook.

I'm looking forward to seeing this in production!