### PR TITLE
Ability to replace a label (replace an old label with a new label)

### DIFF
--- a/mxnet-bot/LabelBotFullFunctionality/LabelBot.py
+++ b/mxnet-bot/LabelBotFullFunctionality/LabelBot.py
@@ -191,6 +191,23 @@ class LabelBot:
                           .format(str(issue_num), str(labels), json.dumps(response.json())))
             return False
 
+    def replace_label(self, issue_num, labels):
+        """
+        This method is to change a label to another in an issue
+        :param issue_num: The specific issue number we want to label
+        :param labels: The labels which we want to change from and to
+        :return: Response denoting success or failure for logging purposes
+        """
+        labels = self._format_labels(labels)
+        if len(labels) != 2:
+            logging.error('Must only specify 2 labels when wanting to change labels')
+            return False
+        logging.info('Label on {} to change from: {} to {}'.format(str(issue_num), str(labels[0]), str(labels[1])))
+        if self.remove_labels(issue_num, [labels[0]]) and self.add_labels(issue_num, [labels[1]]):
+            return True
+        else:
+            return False
+
     def label_action(self, actions):
         """
         This method will perform an actions for the labels that are provided. This function delegates
@@ -204,6 +221,8 @@ class LabelBot:
             return self.remove_labels(actions["remove"][0], actions["remove"][1])
         elif "update" in actions:
             return self.update_labels(actions["update"][0], actions["update"][1])
+        elif "replace" in actions:
+            return self.replace_label(actions["replace"][0], actions["replace"][1])
         else:
             return False
 

--- a/mxnet-bot/LabelBotFullFunctionality/README.md
+++ b/mxnet-bot/LabelBotFullFunctionality/README.md
@@ -1,11 +1,13 @@
 # label bot
 This bot serves to help non-committers add labels to GitHub issues.
 
-"Hi @mxnet-label-bot, please add labels: [operator, feature request]"
+"Hi @mxnet-label-bot, add [operator, feature request]"
 
-"Hi @mxnet-label-bot remove labels : [operator, feature request]"
+"Hi @mxnet-label-bot remove [operator, feature request]"
 
-"Hi @mxnet-label-bot update labels : [operator, feature request]"
+"Hi @mxnet-label-bot update [operator, feature request]"
+
+"Hi @mxnet-label-bot replace [operator, feature request]"
 
 ## Setup
 **Make sure that all settings is in the same *AWS region***

--- a/mxnet-bot/LabelBotFullFunctionality/README.md
+++ b/mxnet-bot/LabelBotFullFunctionality/README.md
@@ -1,7 +1,7 @@
 # label bot
 This bot serves to help non-committers add labels to GitHub issues.
 
-"Hi @mxnet-label-bot, add [operator, feature request]"
+"Hi @mxnet-label-bot add [operator, feature request]"
 
 "Hi @mxnet-label-bot remove [operator, feature request]"
 


### PR DESCRIPTION
Replaces a label:
  - separates replacement functionality and update 
  - replace does a single label replacement (as update removes existing labels and updates to labels specified)

(i.e. replace [c,c++] changes only specific c label to c++)
Fixes #46 