### PR TITLE
Upgraded dependencies to avoid security risks

### DIFF
--- a/mxnet-bot/PredictLabels/requirements.txt
+++ b/mxnet-bot/PredictLabels/requirements.txt
@@ -12,7 +12,7 @@ docutils==0.14
 Flask==1.0.2
 idna==2.7
 itsdangerous==0.24
-Jinja2==2.10
+Jinja2==2.10.1
 jmespath==0.9.3
 kiwisolver==1.0.1
 matplotlib==2.2.2
@@ -28,6 +28,6 @@ scikit-learn==0.19.2
 scipy==1.1.0
 six==1.11.0
 sklearn==0.0
-urllib3==1.23
+urllib3==1.24.2
 Werkzeug==0.14.1
 zope.interface==4.5.0


### PR DESCRIPTION
GitHub sent a notification alerting that our current versions of Jinja2 and Urllib have vulnerabilitites, upgrading them to the recommended version.